### PR TITLE
Updates to improve/fix correlation mapping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scrattch.mapping
 Title: Generalized mapping of annotations from shiny taxonomy to query
         data.
-Version: 0.55.6
+Version: 0.7.1
 Authors@R: 
     person(given = "Nelson",
            family = "Johansen",

--- a/R/seuratMap.R
+++ b/R/seuratMap.R
@@ -2,26 +2,67 @@
 #'
 #' @param AIT.anndata A reference taxonomy anndata object.
 #' @param query.data A logCPM normalized matrix to be annotated.
+#' @param dims Number of principle component dimensions to use for FindTransferAnchors and TransferData (default = 30)
+#' @param k.weight k.weight parameter for TransferData Seurat function (default = 5)
+#' @param genes.to.use The set of genes to use for Seurat variable genes (default is the highly_variable_genes associated with the current mode). Can either be a character vector of gene names or a TRUE/FALSE (logical) vector of which genes to include.
+#' @param cells.to.use The set of cells to include in Seurat integration (default is the filtered cell set associated with the current mode). Can either be a character vector of cell names or a TRUE/FALSE (logical) vector of which cells to include.
 #'
 #' @return Seurat mapping results as a data.frame.
 #'
 #' @export
-seuratMap = function(AIT.anndata, query.data, dims=30, k.weight=5){
+seuratMap = function(AIT.anndata, 
+                     query.data, 
+                     dims=30, 
+                     k.weight=5,
+                     genes.to.use=NULL,
+                     cells.to.use=NULL){
     print("Seurat-based mapping")
 
     ## Attempt Seurat mapping
     mappingTarget = tryCatch(
         expr = {
+            ## Create the vector of genes to use.
+            if(is.null(genes.to.use)){
+              # If null, default to correct set of highly variable genes
+              genes.to.use.vector <- AIT.anndata$var[,paste0("highly_variable_genes_",AIT.anndata$uns$mode)]
+            } else if (is.logical(genes.to.use)) {
+              if (length(genes.to.use)!=dim(AIT.anndata)[2]) stop("If genes.to.use is logical it must be the same length as the total number of genes in AIT.anndata.")
+              genes.to.use.vector = genes.to.use
+            } else if (is.character(genes.to.use)){
+              genes.to.use <- intersect(genes.to.use,AIT.anndata$var_names)
+              if (length(genes.to.use)==0) stop("No valid gene names provided in genes.to.use.")
+              if (length(genes.to.use)<=2) stop("More than 2 valid gene names must be provided in genes.to.use.")
+              genes.to.use.vector <- is.element(AIT.anndata$var_names,genes.to.use)
+            } else {
+              stop("genes.to.use must be a character or logical vector.")
+            }
+          
+            ## Create the vector of cells to use.
+            if(is.null(cells.to.use)){
+              # If null, default to correct set of highly variable genes
+              cells.to.use.vector <- !AIT.anndata$uns$filter[[AIT.anndata$uns$mode]]
+            } else if (is.logical(cells.to.use)) {
+              if (length(cells.to.use)!=dim(AIT.anndata)[1]) stop("If cells.to.use is logical it must be the same length as the total number of cells in AIT.anndata.")
+              cells.to.use.vector = cells.to.use
+            } else if (is.character(cells.to.use)){
+              cells.to.use <- intersect(cells.to.use,AIT.anndata$obs_names)
+              if (length(cells.to.use)==0) stop("No valid cell names provided in cells.to.use")
+              if (length(cells.to.use)<=2) stop("More than 2 valid cell names must be provided in cells.to.use.")
+              cells.to.use.vector <- is.element(AIT.anndata$obs_names,cells.to.use)
+            } else {
+              stop("cells.to.use must be a character or logical vector.")
+            }
 
-            ## Build Query Seruat object
-            use.genes    = intersect(rownames(query.data),AIT.anndata$var_names[AIT.anndata$var$highly_variable_genes])
+            ## Build Query Seurat object
+            use.genes    = intersect(rownames(query.data),AIT.anndata$var_names[genes.to.use.vector])
             query.seurat = suppressWarnings(CreateSeuratObject(query.data[use.genes,]))
             query.seurat = suppressWarnings(SetAssayData(query.seurat, slot = "data", new.data = query.data[use.genes,], assay = "RNA"))
             VariableFeatures(query.seurat) <- use.genes
             
             ## Build Ref Seurat object
             ref.data   = as.matrix(BiocGenerics::t(AIT.anndata$X[,use.genes]))
-            ref.seurat = suppressWarnings(CreateSeuratObject(ref.data, meta.data=as.data.frame(AIT.anndata$obs)));
+            ref.data   = ref.data[,cells.to.use.vector]# UPDATE to filter cells
+            ref.seurat = suppressWarnings(CreateSeuratObject(ref.data, meta.data=as.data.frame(AIT.anndata$obs)[cells.to.use.vector,]));
             ref.seurat = suppressWarnings(SetAssayData(ref.seurat, slot = "data", new.data = ref.data, assay = "RNA"))
             VariableFeatures(ref.seurat) <- use.genes
 

--- a/R/taxonomyMapping.R
+++ b/R/taxonomyMapping.R
@@ -1,28 +1,42 @@
 #' Cell type annotation and initial QC
 #'
-#' Perform initial mapping using three methods: Correlation-based, tree-based, and Seurat based, and will calculate some QC metrics.   
+#' This function performs mapping using four methods (Correlation-based, tree-based, heirarchical, and Seurat-based) and will return the top one (or in some cases more) best matching reference cell type along with some associated QC metrics.   
 #'
 #' @param AIT.anndata A reference taxonomy object.
 #' @param query.data A logCPM normalized matrix to be annotated.
-#' @param label.cols Column names of annotations to map against.  Note that this only works for metadata that represent clusters or groups of clusters (e.g., subclass, supertype, neighborhood, class) and will default to whatever is included in AIT.anndata$uns$hierarchy
-#' @param corr.map Should correlation mapping be performed?
-#' @param tree.map Should tree mapping be performed?
-#' @param seurat.map Should seurat mapping be performed?
+#' @param label.cols Column names of annotations to map against.  Note that this only works for metadata that represent clusters or groups of clusters (e.g., subclass, supertype, neighborhood, class) and will default to whatever is included in AIT.anndata$uns$hierarchy. This is highly related to the variable called "hierarchy" in other functions.
+#' @param corr.map Should correlation mapping be performed? (see methods)
+#' @param tree.map Should tree mapping be performed? (see methods)
+#' @param hierarchical.map Should hierarchical mapping be performed? (see methods)
+#' @param seurat.map Should seurat mapping be performed? (see methods)
+#' @param genes.to.use The set of genes to use for correlation calculation and/or Seurat integration (default is the highly_variable_genes associated with the current mode). Can either be a character vector of gene names or a TRUE/FALSE (logical) vector of which genes to include.
+#'
+#' Mapping methods currently available in `taxonomy_mapping` include:  
+#' 
+#' 1. **corr.map**: This method calculates the Pearson correlation between each cell and each cluster median, and returns the cluster with the highest correlation along with the associated correlation score. Despite being a very simple method, this works quite well in some circumstances.  
+#' 2. **tree.map**: Historical implementation of tree mapping used for assigning cell types to patch-seq cells in several studies of mouse visual cortex. This method requires a dendogram and iteratively walks down the tree from the root node to the leave nodes deciding the most likely cell type based on a distict set of marker genes at each node. By subsampling genes, this method provides a bootstrapping probability/confidence. *Implementation of tree mapping herein is not fully tested, so use with caution.*  
+#' 3. **hierarchical.map**: Current version of iterative (or hierarchical) mapping used in MapMyCells, this function imports the python `cell_type_mapper` library. It requires a leveled hierarchy (e.g., cluster columns corresponding to cell type definitions at different levels of resolutions such as "cluster" and "subclass" and "class") and performs correlation-based mapping with different marker genes for each level, iterating through the levels similar to tree mapping. Like tree mapping this method provides a bootstrapping probability/confidence by subsampling genes. We find that this method works quite well in some circumstances.  
+#' 4. **flat.map** (coming soon!): A single-level implementation of hierarchical mapping. Essentially it is the same as corr.map, except that it uses a prespecified set of marker genes for calculating the correlation and that it outputs bootstrapping probabilities.
+#' 5. **seurat.map**: Historical implementation of Seurat mapping for assigning cell types to patch-seq cells in a study of human temporal cortex. This method performs integration and label transfer using `FindTransferAnchors` and `TransferData` functions in Seurat (v4.4.0) with a prespecified set of variable genes and a reasonable set of parameters. *We are not maintaining this method for compatibility in Seurat versions 5.0 or higher, and therefore this function will likely fail outside of the Docker environment.*  
 #'
 #' @return Mapping results from all methods.
 #'
 #' @export
-taxonomy_mapping = function(AIT.anndata, query.data, 
-                            corr.map=TRUE, tree.map=TRUE, hierarchical.map=TRUE, seurat.map=TRUE, 
-                            label.cols = AIT.anndata$uns$hierarchy){  # NOTE THE NEW DEFAULT
-                            #label.cols = c("cluster_label","subclass_label", "class_label")){
+taxonomy_mapping = function(AIT.anndata, 
+                            query.data, 
+                            corr.map=TRUE, 
+                            tree.map=TRUE, 
+                            hierarchical.map=TRUE, 
+                            seurat.map=TRUE, 
+                            label.cols = AIT.anndata$uns$hierarchy,  # NOTE THE NEW DEFAULT
+                            genes.to.use = NULL){ 
 
   suppressWarnings({ # wrapping the whole function in suppressWarnings to avoid having this printed a zillion times: 'useNames = NA is deprecated. Instead, specify either useNames = TRUE or useNames = FALSE.'
   
     print(paste("==============================","Mapping","======================="))
     print(date())
     mappingResults=list()
-    if(sum(class(label.cols)=="list")<1) label.cols = as.character(hierarchy) # Convert from list to character for this function
+    if(sum(class(label.cols)=="list")<1) label.cols = as.character(label.cols) # Convert from list to character for this function
 
     ## Sanity check on user input and taxonomy/reference annotations
     if(!all(label.cols %in% colnames(AIT.anndata$uns$clusterInfo))){
@@ -31,26 +45,43 @@ taxonomy_mapping = function(AIT.anndata, query.data,
 
     ## Modify taxonomy based on mapping mode
     if(!is.element("mode", names(AIT.anndata$uns))){
-      print("Mapping in mode: `standard`. No filtering.")
+      print("Mapping in mode: `standard` with no subsampling. No filtering.")
     } else if(!AIT.anndata$uns$mode %in% names(AIT.anndata$uns$filter)){
       stop(print("Mapping mode, ", AIT.anndata$uns$mode, ", is not available for current Taxonomy."))
     } else{
-      ## Remove off-target cell types
+      ## Message if subsampling is used
+      if(sum(AIT.anndata$uns$filter[[AIT.anndata$uns$mode]])>0){
+        print("Removing off-target cell types and/or subsampled cells.")
+      }
+      ## Remove off-target cell types and/or subsampled cells
       AIT.anndata = AIT.anndata[!AIT.anndata$uns$filter[[AIT.anndata$uns$mode]]]
       AIT.anndata$uns$clusterInfo = AIT.anndata$uns$clusterInfo %>% filter(cluster_label %in% unique(AIT.anndata$obs$cluster_label))
       AIT.anndata$uns$clustersUse = unique(AIT.anndata$obs$cluster_label)
+      AIT.anndata$uns$filter[[AIT.anndata$uns$mode]] <- rep(FALSE,sum(!AIT.anndata$uns$filter[[AIT.anndata$uns$mode]])) # New for compatibility with Seurat mapping updates
     }
 
     ############
     ## ----- data and annotation variables -------------------------------------------------------------
 
     ## Ensure variable features are in common across data
+    ## -- UPDATE: pull from the mode-based highly variable gene set rather than the generic one
     AIT.anndata$var$common_genes = AIT.anndata$var$gene %in% rownames(query.data)
-    AIT.anndata$var$highly_variable_genes = AIT.anndata$var$highly_variable_genes & AIT.anndata$var$common_genes
+    highvar.check <- paste0("highly_variable_genes_",AIT.anndata$uns$mode)
+    if(!is.element(highvar.check,colnames(AIT.anndata$var))){
+      print(paste("Highly variable genes for",AIT.anndata$uns$mode,"not found! Defaulting to global highly variable genes."))
+      highly_variable_genes_mode = AIT.anndata$var$highly_variable_genes
+    } else {
+      highly_variable_genes_mode = AIT.anndata$var[,highvar.check]
+    }
+    AIT.anndata$var$highly_variable_genes = highly_variable_genes_mode & AIT.anndata$var$common_genes
 
     ############
     ## ----- Correlation mapping ------------------------------------------------------------------------
-    if(corr.map == TRUE){ mappingResults[["Corr"]] = corrMap(AIT.anndata, query.data) } else  { mappingResults[["Corr"]] = NULL }
+    if(corr.map == TRUE){ 
+      mappingResults[["Corr"]] = corrMap(AIT.anndata, query.data, genes.to.use = genes.to.use) 
+    } else { 
+      mappingResults[["Corr"]] = NULL 
+    }
     
     #############
     ## ----- Tree mapping -------------------------------------------------------------------------------
@@ -63,7 +94,11 @@ taxonomy_mapping = function(AIT.anndata, query.data,
     
     #############
     ## ----- Seurat mapping ------------------------------------------------------------------------------
-    if(seurat.map == TRUE){ mappingResults[["Seurat"]] = seuratMap(AIT.anndata, query.data) } else{ mappingResults[["Seurat"]] = NULL }
+    if(seurat.map == TRUE){ 
+      mappingResults[["Seurat"]] = seuratMap(AIT.anndata, query.data, genes.to.use = genes.to.use) 
+    } else { 
+      mappingResults[["Seurat"]] = NULL 
+    }
 
     #############
     ## ----- Hierarchical mapping ------------------------------------------------------------------------------

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,20 @@
+## scrattch.mapping v0.7.1
+
+Updates to improve correlation mapping
+
+### Major changes
+* Updated `taxonomyMapping` wrapper to allow flexibility, while keeping defaults and back-compatibility intact
+* Updated `corrMap` to allow gene list or logical input, and to default to appropriate variable gene set
+* Updated `seuratMap` the same way, and also to only pull mode-specific cells and clusters
+* Updated all three of the above functions to properly consider the current mode  
+
+### Minor changes
+* Synchronized versions between scrattch.taxonomy, scrattch.mapping, an scrattch.patchseq
+* Error correction
+* Improved documentation on mapping methods
+
+--
+
 ## scrattch.mapping v0.55.6
 
 Updates to streamline and fix the examples

--- a/man/corrMap.Rd
+++ b/man/corrMap.Rd
@@ -4,12 +4,14 @@
 \alias{corrMap}
 \title{Correlation based mapping}
 \usage{
-corrMap(AIT.anndata, query.data)
+corrMap(AIT.anndata, query.data, genes.to.use = NULL)
 }
 \arguments{
 \item{AIT.anndata}{A reference taxonomy anndata object.}
 
 \item{query.data}{A logCPM normalized matrix to be annotated.}
+
+\item{genes.to.use}{The set of genes to use for correlation calculation (default is the highly_variable_genes associated with the current mode). Can either be a character vector of gene names or a TRUE/FALSE (logical) vector of which genes to include.}
 }
 \value{
 Correlation mapping results as a data.frame.

--- a/man/seuratMap.Rd
+++ b/man/seuratMap.Rd
@@ -4,12 +4,27 @@
 \alias{seuratMap}
 \title{Seurat based mapping}
 \usage{
-seuratMap(AIT.anndata, query.data, dims = 30, k.weight = 5)
+seuratMap(
+  AIT.anndata,
+  query.data,
+  dims = 30,
+  k.weight = 5,
+  genes.to.use = NULL,
+  cells.to.use = NULL
+)
 }
 \arguments{
 \item{AIT.anndata}{A reference taxonomy anndata object.}
 
 \item{query.data}{A logCPM normalized matrix to be annotated.}
+
+\item{dims}{Number of principle component dimensions to use for FindTransferAnchors and TransferData (default = 30)}
+
+\item{k.weight}{k.weight parameter for TransferData Seurat function (default = 5)}
+
+\item{genes.to.use}{The set of genes to use for Seurat variable genes (default is the highly_variable_genes associated with the current mode). Can either be a character vector of gene names or a TRUE/FALSE (logical) vector of which genes to include.}
+
+\item{cells.to.use}{The set of cells to include in Seurat integration (default is the filtered cell set associated with the current mode). Can either be a character vector of cell names or a TRUE/FALSE (logical) vector of which cells to include.}
 }
 \value{
 Seurat mapping results as a data.frame.

--- a/man/taxonomy_mapping.Rd
+++ b/man/taxonomy_mapping.Rd
@@ -11,7 +11,8 @@ taxonomy_mapping(
   tree.map = TRUE,
   hierarchical.map = TRUE,
   seurat.map = TRUE,
-  label.cols = AIT.anndata$uns$hierarchy
+  label.cols = AIT.anndata$uns$hierarchy,
+  genes.to.use = NULL
 )
 }
 \arguments{
@@ -19,17 +20,30 @@ taxonomy_mapping(
 
 \item{query.data}{A logCPM normalized matrix to be annotated.}
 
-\item{corr.map}{Should correlation mapping be performed?}
+\item{corr.map}{Should correlation mapping be performed? (see methods)}
 
-\item{tree.map}{Should tree mapping be performed?}
+\item{tree.map}{Should tree mapping be performed? (see methods)}
 
-\item{seurat.map}{Should seurat mapping be performed?}
+\item{hierarchical.map}{Should hierarchical mapping be performed? (see methods)}
 
-\item{label.cols}{Column names of annotations to map against.  Note that this only works for metadata that represent clusters or groups of clusters (e.g., subclass, supertype, neighborhood, class) and will default to whatever is included in AIT.anndata$uns$hierarchy}
+\item{seurat.map}{Should seurat mapping be performed? (see methods)}
+
+\item{label.cols}{Column names of annotations to map against.  Note that this only works for metadata that represent clusters or groups of clusters (e.g., subclass, supertype, neighborhood, class) and will default to whatever is included in AIT.anndata$uns$hierarchy. This is highly related to the variable called "hierarchy" in other functions.}
+
+\item{genes.to.use}{The set of genes to use for correlation calculation and/or Seurat integration (default is the highly_variable_genes associated with the current mode). Can either be a character vector of gene names or a TRUE/FALSE (logical) vector of which genes to include.
+
+Mapping methods currently available in \code{taxonomy_mapping} include:
+\enumerate{
+\item \strong{corr.map}: This method calculates the Pearson correlation between each cell and each cluster median, and returns the cluster with the highest correlation along with the associated correlation score. Despite being a very simple method, this works quite well in some circumstances.
+\item \strong{tree.map}: Historical implementation of tree mapping used for assigning cell types to patch-seq cells in several studies of mouse visual cortex. This method requires a dendogram and iteratively walks down the tree from the root node to the leave nodes deciding the most likely cell type based on a distict set of marker genes at each node. By subsampling genes, this method provides a bootstrapping probability/confidence. \emph{Implementation of tree mapping herein is not fully tested, so use with caution.}
+\item \strong{hierarchical.map}: Current version of iterative (or hierarchical) mapping used in MapMyCells, this function imports the python \code{cell_type_mapper} library. It requires a leveled hierarchy (e.g., cluster columns corresponding to cell type definitions at different levels of resolutions such as "cluster" and "subclass" and "class") and performs correlation-based mapping with different marker genes for each level, iterating through the levels similar to tree mapping. Like tree mapping this method provides a bootstrapping probability/confidence by subsampling genes. We find that this method works quite well in some circumstances.
+\item \strong{flat.map} (coming soon!): A single-level implementation of hierarchical mapping. Essentially it is the same as corr.map, except that it uses a prespecified set of marker genes for calculating the correlation and that it outputs bootstrapping probabilities.
+\item \strong{seurat.map}: Historical implementation of Seurat mapping for assigning cell types to patch-seq cells in a study of human temporal cortex. This method performs integration and label transfer using \code{FindTransferAnchors} and \code{TransferData} functions in Seurat (v4.4.0) with a prespecified set of variable genes and a reasonable set of parameters. \emph{We are not maintaining this method for compatibility in Seurat versions 5.0 or higher, and therefore this function will likely fail outside of the Docker environment.}
+}}
 }
 \value{
 Mapping results from all methods.
 }
 \description{
-Perform initial mapping using three methods: Correlation-based, tree-based, and Seurat based, and will calculate some QC metrics.
+This function performs mapping using four methods (Correlation-based, tree-based, heirarchical, and Seurat-based) and will return the top one (or in some cases more) best matching reference cell type along with some associated QC metrics.
 }


### PR DESCRIPTION
## scrattch.mapping v0.7.1

Updates to improve correlation mapping

### Major changes
* Updated `taxonomyMapping` wrapper to allow flexibility, while keeping defaults and back-compatibility intact
* Updated `corrMap` to allow gene list or logical input, and to default to appropriate variable gene set
* Updated `seuratMap` the same way, and also to only pull mode-specific cells and clusters
* Updated all three of the above functions to properly consider the current mode  

### Minor changes
* Synchronized versions between scrattch.taxonomy, scrattch.mapping, an scrattch.patchseq
* Error correction
* Improved documentation on mapping methods
